### PR TITLE
Member 도메인 REST 컨트롤러 만들기

### DIFF
--- a/src/main/java/jpabook/jpashop/api/MemberApiController.java
+++ b/src/main/java/jpabook/jpashop/api/MemberApiController.java
@@ -1,0 +1,9 @@
+package jpabook.jpashop.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberApiController {
+}

--- a/src/main/java/jpabook/jpashop/api/MemberApiController.java
+++ b/src/main/java/jpabook/jpashop/api/MemberApiController.java
@@ -9,6 +9,9 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestController
 @RequiredArgsConstructor
 public class MemberApiController {
@@ -27,6 +30,21 @@ public class MemberApiController {
 
         Long id = memberService.create(member);
         return new CreateMemberResponse(id);
+    }
+
+    @Data
+    public static class CreateMemberRequest {
+        @NotEmpty
+        private String name;
+    }
+
+    @Data
+    public static class CreateMemberResponse {
+        private Long id;
+
+        public CreateMemberResponse(Long id) {
+            this.id = id;
+        }
     }
 
     @PatchMapping("/api/v2/members/{id}")
@@ -50,18 +68,29 @@ public class MemberApiController {
         private String name;
     }
 
-    @Data
-    public static class CreateMemberRequest {
-        @NotEmpty
-        private String name;
+    @GetMapping("/api/v1/members")
+    public List<Member> getMembersV1() {
+        return memberService.findMembers();
+    }
+
+    @GetMapping("/api/v2/members")
+    public ResponseData getMembersV2() {
+        List<Member> members = memberService.findMembers();
+        List<MemberDto> collect = members.stream()
+                .map(m -> new MemberDto(m.getUsername()))
+                .toList();
+        return new ResponseData(collect);
     }
 
     @Data
-    public static class CreateMemberResponse {
-        private Long id;
+    @AllArgsConstructor
+    public static class ResponseData<T> {
+        private T data;
+    }
 
-        public CreateMemberResponse(Long id) {
-            this.id = id;
-        }
+    @Data
+    @AllArgsConstructor
+    public static class MemberDto {
+        private String name;
     }
 }

--- a/src/main/java/jpabook/jpashop/api/MemberApiController.java
+++ b/src/main/java/jpabook/jpashop/api/MemberApiController.java
@@ -4,11 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jpabook.jpashop.domain.Member;
 import jpabook.jpashop.service.MemberService;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +27,27 @@ public class MemberApiController {
 
         Long id = memberService.create(member);
         return new CreateMemberResponse(id);
+    }
+
+    @PatchMapping("/api/v2/members/{id}")
+    public PatchMemberResponse patchMemberV2(
+            @PathVariable("id") Long id,
+            @RequestBody @Valid PatchMemberRequest request) {
+        memberService.patch(id, request.getName());
+        Member member = memberService.findOne(id);
+        return new PatchMemberResponse(member.getId(), member.getUsername());
+    }
+
+    @Data
+    public static class PatchMemberRequest {
+        private String name;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class PatchMemberResponse {
+        private Long id;
+        private String name;
     }
 
     @Data

--- a/src/main/java/jpabook/jpashop/api/MemberApiController.java
+++ b/src/main/java/jpabook/jpashop/api/MemberApiController.java
@@ -1,9 +1,47 @@
 package jpabook.jpashop.api;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jpabook.jpashop.domain.Member;
+import jpabook.jpashop.service.MemberService;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class MemberApiController {
+    private final MemberService memberService;
+
+    @PostMapping("/api/v1/members")
+    public CreateMemberResponse saveMemberV1(@RequestBody @Valid Member member) {
+        Long id = memberService.create(member);
+        return new CreateMemberResponse(id);
+    }
+
+    @PostMapping("/api/v2/members")
+    public CreateMemberResponse saveMemberV2(@RequestBody @Valid CreateMemberRequest request) {
+        Member member = new Member();
+        member.setUsername(request.getName());
+
+        Long id = memberService.create(member);
+        return new CreateMemberResponse(id);
+    }
+
+    @Data
+    public static class CreateMemberRequest {
+        @NotEmpty
+        private String name;
+    }
+
+    @Data
+    public static class CreateMemberResponse {
+        private Long id;
+
+        public CreateMemberResponse(Long id) {
+            this.id = id;
+        }
+    }
 }

--- a/src/main/java/jpabook/jpashop/service/MemberService.java
+++ b/src/main/java/jpabook/jpashop/service/MemberService.java
@@ -28,6 +28,12 @@ public class MemberService {
         }
     }
 
+    @Transactional
+    public void patch(Long id, String name) {
+        Member member = memberRepository.findOne(id);
+        member.setUsername(name);
+    }
+
     // 회원 전체 조회
 
     public List<Member> findMembers() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
#### 회원 등록
엔티티 API 스펙에 직접 노출시 문제점
- 엔티티에 프레젠테이션 계층을 위한 로직이 추가된다.
- 엔티티에 API 검증을 위한 로직이 들어간다. (`@NotEmpty` 등등)
- 실무에서는 회원 엔티티를 위한 API가 다양하게 만들어지는데, 한 엔티티에 각각의 API를 위한
모든 요청 요구사항을 담기는 어렵다.
- 엔티티가 변경되면 API 스펙이 변한다.
결론
- API 요청 스펙에 맞추어 별도의 DTO를 파라미터로 받는다.

#### 회원 수정

커멘드성 (쓰기) 로직에서는 가급적 변경된 엔티티 객체를 바로 넘겨주지 말자. 그럴 경우 커멘드와 쿼리가 섞이게 되어 좋지 못한 코드가 될 수 있다. 아래와 같이 단일 레코드일때는 마지막에 쿼리를 한번 더 해서 해당 엔티티로 응답을 만들어 보내는 방법도 성능면에서 그리 부담이 없기 때문에 괜찮다.

```java
@PatchMapping("/api/v2/members/{id}")
    public PatchMemberResponse patchMemberV2(
            @PathVariable("id") Long id,
            @RequestBody @Valid PatchMemberRequest request) {
        memberService.patch(id, request.getName());
        Member member = memberService.findOne(id);
        return new PatchMemberResponse(member.getId(), member.getUsername());
    }
```

#### 회원 조회
조회 V1: 응답 값으로 엔티티를 직접 외부에 노출한다.
문제점
- 엔티티에 프레젠테이션 계층을 위한 로직이 추가된다.
- 기본적으로 엔티티의 모든 값이 노출된다.
- 응답 스펙을 맞추기 위해 로직이 추가된다. (`@JsonIgnore`, 별도의 뷰 로직 등등)
- 실무에서는 같은 엔티티에 대해 API가 용도에 따라 다양하게 만들어지는데, 한 엔티티에 각각의
API를 위한 프레젠테이션 응답 로직을 담기는 어렵다.
- 엔티티가 변경되면 API 스펙이 변한다.
- 추가로 컬렉션을 직접 반환하면 항후 API 스펙을 변경하기 어렵다.(별도의 Result 클래스 생성으
로 해결)
결론
- API 응답 스펙에 맞추어 별도의 DTO를 반환한다.

