### PR TITLE
간단한 주문 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/jpabook/jpashop/InitDb.java
+++ b/src/main/java/jpabook/jpashop/InitDb.java
@@ -1,0 +1,83 @@
+package jpabook.jpashop;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.domain.item.Book;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class InitDb {
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit1();
+        initService.dbInit2();
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    @Transactional
+    static class InitService {
+        private final EntityManager em;
+
+        public void dbInit1() {
+            Member member = createMember("userA", "서울", "1", "1111");
+            em.persist(member);
+
+            Book book1 = createBook("JPA1 BOOK", 10000, 100);
+            em.persist(book1);
+
+            Book book2 = createBook("JPA2 Book", 20000, 100);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+            Order order = Order.createOrder(member, createDelivery(member), orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        public void dbInit2() {
+            Member member = createMember("userB","진주", "2", "2222");
+            em.persist(member);
+
+            Book book1 = createBook("SPRING1 BOOK", 20000, 200);
+            em.persist(book1);
+
+            Book book2 = createBook("SPRING2 BOOK", 40000, 300);
+            em.persist(book2);
+
+            Delivery delivery = createDelivery(member);
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 20000, 3);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 40000, 4);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private Member createMember(String name, String city, String street, String zipcode) {
+            Member member = new Member();
+            member.setUsername(name);
+            member.setAddress(new Address(city, street, zipcode));
+            return member;
+        }
+
+        private Book createBook(String name, int price, int stockQuantity) {
+            Book book = new Book();
+            book.setName(name);
+            book.setPrice(price);
+            book.setStockQuantity(stockQuantity);
+            return book;
+        }
+
+        private Delivery createDelivery(Member member) {
+            Delivery delivery = new Delivery();
+            delivery.setAddress(member.getAddress());
+            return delivery;
+        }
+    }
+}

--- a/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop;
 
+import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class JpashopApplication {
@@ -11,4 +13,8 @@ public class JpashopApplication {
 		SpringApplication.run(JpashopApplication.class, args);
 	}
 
+	@Bean
+	Hibernate5JakartaModule hibernate5JakartaModule() {
+		return new Hibernate5JakartaModule();
+	}
 }

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -37,6 +37,12 @@ public class OrderSimpleApiController {
         return all.stream().map(order -> new SimpleOrderDto(order)).toList();
     }
 
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        return orders.stream().map(SimpleOrderDto::new).toList();
+    }
+
     @Data
     public static class SimpleOrderDto {
         private Long orderId;

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -5,6 +5,8 @@ import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderSearch;
 import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryRepository;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ import static java.util.stream.Collectors.toList;
 public class OrderSimpleApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderSimpleQueryRepository orderSimpleQueryRepository;
 
     @GetMapping("/api/v1/simple-orders")
     public List<Order> ordersV1() {
@@ -41,6 +44,11 @@ public class OrderSimpleApiController {
     public List<SimpleOrderDto> ordersV3() {
         List<Order> orders = orderRepository.findAllWithMemberDelivery();
         return orders.stream().map(SimpleOrderDto::new).toList();
+    }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<OrderSimpleQueryDto> ordersV4() {
+        return orderSimpleQueryRepository.findOrderDtos();
     }
 
     @Data

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,13 +1,19 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.OrderSearch;
+import jpabook.jpashop.domain.OrderStatus;
 import jpabook.jpashop.repository.OrderRepository;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +29,28 @@ public class OrderSimpleApiController {
             order.getDelivery().getAddress();
         }
         return all;
+    }
+
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> ordersV2() {
+        List<Order> all = orderRepository.findAll(new OrderSearch());
+        return all.stream().map(order -> new SimpleOrderDto(order)).toList();
+    }
+
+    @Data
+    public static class SimpleOrderDto {
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) {
+            orderId = order.getId();
+            name = order.getMember().getUsername();
+            orderDate = order.getOrderDate();
+            orderStatus = order.getStatus();
+            address = order.getDelivery().getAddress();
+        }
     }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,27 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderSearch;
+import jpabook.jpashop.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+
+    private final OrderRepository orderRepository;
+
+    @GetMapping("/api/v1/simple-orders")
+    public List<Order> ordersV1() {
+        List<Order> all = orderRepository.findAll(new OrderSearch());
+        for (Order order: all) {
+            order.getMember().getUsername();
+            order.getDelivery().getAddress();
+        }
+        return all;
+    }
+}

--- a/src/main/java/jpabook/jpashop/domain/Delivery.java
+++ b/src/main/java/jpabook/jpashop/domain/Delivery.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,6 +15,7 @@ public class Delivery {
     private Long id;
 
     @OneToOne(mappedBy = "delivery", fetch = LAZY)
+    @JsonIgnore
     private Order order;
 
     @Embedded

--- a/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/src/main/java/jpabook/jpashop/domain/Member.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,5 +21,6 @@ public class Member {
     private Address address;
 
     @OneToMany(mappedBy = "member")
+    @JsonIgnore
     private List<Order> orders = new ArrayList<>();
 }

--- a/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.jpashop.domain.item.Item;
 import lombok.Getter;
@@ -20,6 +21,7 @@ public class OrderItem {
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "order_id")
+    @JsonIgnore
     private Order order;
 
     private int orderPrice;

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -53,4 +53,9 @@ public class OrderRepository {
         TypedQuery<Order> query = em.createQuery(cq).setMaxResults(1000); //최대 1000건
         return query.getResultList();
     }
+
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
+                .getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
@@ -1,0 +1,30 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderSimpleQueryDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private OrderStatus orderStatus;
+    private Address address;
+
+    public OrderSimpleQueryDto(
+            Long orderId,
+            String name,
+            LocalDateTime orderDate,
+            OrderStatus orderStatus,
+            Address address
+    ) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
@@ -1,0 +1,23 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSimpleQueryRepository {
+    private final EntityManager em;
+
+    public List<OrderSimpleQueryDto> findOrderDtos() {
+        return em.createQuery(
+                "select new jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto(o.id, m.username, o.orderDate, o.status, d.address)"
+                + " from Order o"
+                + " join o.member m"
+                + " join o.delivery d",
+                OrderSimpleQueryDto.class
+        ).getResultList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,5 +17,5 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+#    org.hibernate.orm.jdbc.bind: trace
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
 
-logging:
-  level:
-    org.hibernate.SQL: debug
+#logging:
+#  level:
+#    org.hibernate.SQL: debug
 #    org.hibernate.orm.jdbc.bind: trace
 


### PR DESCRIPTION
### 간단한 주문 조회 V1: 엔티티를 직접 노출
* `order -> member`, `order -> delivery` 는 지연 로딩이여서 프록시 객체로 만들어진다. jackson 라이브러리는 기본적으로 이 프록시 객체를 json으로 어떻게 생성해야 하는지 모름 예외 발생
* `Hibernate5JakartaModule` 을 스프링 빈으로 등록하면 해결 가능하지만 몇가지 주의점 존재:
  * 기본적으로 초기화 된 프록시 객체만 노출, 초기화 되지 않은 프록시 객체는 노출 안함
  * 강제로 지연 로딩 관계에 있는 객체들 초기화 가능
     ```java
     hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
     ```
  * 위 옵션을 키거나 지연로딩 객체가 초기화가 되어있다면 `order -> member` , `member -> orders` 양방향 연관관계를 계속 로딩하게 된다. 따라서 `@JsonIgnore` 옵션을 한곳에 주어야 한다.

### 간단한 주문 조회 V2: 엔티티를 DTO로 변환
엔티티를 DTO로 변환하는 일반적인 방법이다. DTO 로 변환하는건 좋지만 그 과정에서 지연로딩되는 필드로 인해 쿼리수가 상당히 많아진다.

쿼리가 총 1 + N + N번 실행된다. (v1과 쿼리수 결과는 같다.)
* `order` 조회 1번(order 조회 결과 수가 N이 된다.)
* `order -> member` 지연 로딩 조회 N 번
* `order -> delivery` 지연 로딩 조회 N 번
* 예) order의 결과가 4개면 최악의 경우 1 + 4 + 4번 실행된다.(최악의 경우) 지연로딩은 영속성 컨텍스트에서 조회하므로, 이미 조회된 경우 쿼리를 생략한다.

### 간단한 주문 조회 V3: 엔티티를 DTO로 변환 - 페치 조인 최적화
```java
public List<Order> findAllWithMemberDelivery() {
        return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
                .getResultList();
}
```
* 엔티티를 페치 조인(fetch join)을 사용해서 쿼리 1번에 조회
* 페치 조인으로 `order -> member` , `order -> delivery` 는 이미 조회 된 상태 이므로 지연로딩X

### 간단한 주문 조회 V4: JPA에서 DTO로 바로 조회
```java
public List<OrderSimpleQueryDto> findOrderDtos() {
        return em.createQuery(
                "select new jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto(o.id, m.username, o.orderDate, o.status, d.address)"
                + " from Order o"
                + " join o.member m"
                + " join o.delivery d",
                OrderSimpleQueryDto.class
        ).getResultList();
    }
```

* 일반적인 SQL을 사용할 때 처럼 원하는 값을 선택해서 조회
* `new` 명령어를 사용해서 JPQL의 결과를 DTO로 즉시 변환
* SELECT 절에서 원하는 데이터를 직접 선택하므로 DB -> 애플리케이션 네트웍 용량 최적화(생각보다 미비)
* 리포지토리 재사용성 떨어짐, API 스펙에 맞춘 코드가 리포지토리에 들어가는 단점

**쿼리 방식 선택 권장 순서**
1. 우선 엔티티를 DTO로 변환하는 방법을 선택한다.
2. 필요하면 페치 조인으로 성능을 최적화 한다. 대부분의 성능 이슈가 해결된다.
3. 그래도 안되면 DTO로 직접 조회하는 방법을 사용한다.
4. 최후의 방법은 JPA가 제공하는 네이티브 SQL이나 스프링 JDBC Template을 사용해서 SQL을 직접 사용한다.