### PR TITLE
API 개발 고급: 컬랙션 조회 최적화

### DIFF
--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -1,6 +1,7 @@
 package jpabook.jpashop.api;
 
 import jpabook.jpashop.domain.*;
+import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.service.OrderService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderApiController {
     private final OrderService orderService;
+    private final OrderRepository orderRepository;
 
     @GetMapping("/api/v1/orders")
     public List<Order> ordersV1() {
@@ -65,5 +67,11 @@ public class OrderApiController {
             this.orderPrice = orderItem.getOrderPrice();
             this.count = orderItem.getCount();
         }
+    }
+
+    @GetMapping("/api/v3/orders")
+    public List<OrderDto> ordersV3() {
+        List<Order> orders = orderRepository.findAllWithItems();
+        return orders.stream().map(OrderDto::new).toList();
     }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -1,0 +1,31 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.service.OrderService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderApiController {
+    private final OrderService orderService;
+
+    @GetMapping("/api/v1/orders")
+    public List<Order> ordersV1() {
+        List<Order> orders = orderService.findOrders(new OrderSearch());
+        for (Order order: orders) {
+            order.getMember().getUsername();
+            order.getDelivery().getAddress();
+            List<OrderItem> orderItems = order.getOrderItems();
+            orderItems.forEach(oi -> oi.getItem().getName());
+        }
+        return orders;
+    }
+
+    
+}

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -2,6 +2,8 @@ package jpabook.jpashop.api;
 
 import jpabook.jpashop.domain.*;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.query.OrderFlatDto;
+import jpabook.jpashop.repository.order.query.OrderItemQueryDto;
 import jpabook.jpashop.repository.order.query.OrderQueryDto;
 import jpabook.jpashop.repository.order.query.OrderQueryRepository;
 import jpabook.jpashop.service.OrderService;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static java.util.stream.Collectors.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -96,5 +100,20 @@ public class OrderApiController {
     @GetMapping("/api/v5/orders")
     public List<OrderQueryDto> ordersV5() {
         return orderQueryRepository.findAllByDto_optimization();
+    }
+
+    @GetMapping("/api/v6/orders")
+    public List<OrderQueryDto> ordersV6() {
+        List<OrderFlatDto> flats = orderQueryRepository.findAllByDto_flat();
+
+        return flats.stream()
+                .collect(groupingBy(o -> new OrderQueryDto(o.getOrderId(),
+                                o.getName(), o.getOrderDate(), o.getOrderStatus(), o.getAddress()),
+                        mapping(o -> new OrderItemQueryDto(o.getOrderId(),
+                                o.getItemName(), o.getOrderPrice(), o.getCount()), toList())
+                )).entrySet().stream()
+                .map(e -> new OrderQueryDto(e.getKey().getOrderId(),
+                        e.getKey().getName(), e.getKey().getOrderDate(), e.getKey().getOrderStatus(),
+                        e.getKey().getAddress(), e.getValue())).collect(toList());
     }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -2,6 +2,8 @@ package jpabook.jpashop.api;
 
 import jpabook.jpashop.domain.*;
 import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.order.query.OrderQueryDto;
+import jpabook.jpashop.repository.order.query.OrderQueryRepository;
 import jpabook.jpashop.service.OrderService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import java.util.List;
 public class OrderApiController {
     private final OrderService orderService;
     private final OrderRepository orderRepository;
+    private final OrderQueryRepository orderQueryRepository;
 
     @GetMapping("/api/v1/orders")
     public List<Order> ordersV1() {
@@ -83,5 +86,10 @@ public class OrderApiController {
     ) {
         List<Order> orders = orderRepository.findAllWithMemberDelivery(offset, limit);
         return orders.stream().map(OrderDto::new).toList();
+    }
+
+    @GetMapping("/api/v4/orders")
+    public List<OrderQueryDto> ordersV4() {
+        return orderQueryRepository.findOrderQueryDtos();
     }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -92,4 +92,9 @@ public class OrderApiController {
     public List<OrderQueryDto> ordersV4() {
         return orderQueryRepository.findOrderQueryDtos();
     }
+
+    @GetMapping("/api/v5/orders")
+    public List<OrderQueryDto> ordersV5() {
+        return orderQueryRepository.findAllByDto_optimization();
+    }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -27,5 +27,43 @@ public class OrderApiController {
         return orders;
     }
 
-    
+    @GetMapping("/api/v2/orders")
+    public List<OrderDto> ordersV2() {
+        List<Order> orders = orderService.findOrders(new OrderSearch());
+        return orders.stream().map(OrderDto::new).toList();
+    }
+
+    @Data
+    public static class OrderDto {
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private OrderStatus orderStatus;
+        private Address address;
+        private List<OrderItemDto> orderItems;
+
+        public OrderDto(Order order) {
+            this.orderId = order.getId();
+            this.name = order.getMember().getUsername();
+            this.orderDate = order.getOrderDate();
+            this.orderStatus = order.getStatus();
+            this.address = order.getDelivery().getAddress();
+            this.orderItems = order.getOrderItems().stream()
+                    .map(OrderItemDto::new)
+                    .toList();
+        }
+    }
+
+    @Data
+    public static class OrderItemDto {
+        private String itemName;
+        private int orderPrice;
+        private int count;
+
+        public OrderItemDto(OrderItem orderItem) {
+            this.itemName = orderItem.getItem().getName();
+            this.orderPrice = orderItem.getOrderPrice();
+            this.count = orderItem.getCount();
+        }
+    }
 }

--- a/src/main/java/jpabook/jpashop/api/OrderApiController.java
+++ b/src/main/java/jpabook/jpashop/api/OrderApiController.java
@@ -6,6 +6,7 @@ import jpabook.jpashop.service.OrderService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -72,6 +73,15 @@ public class OrderApiController {
     @GetMapping("/api/v3/orders")
     public List<OrderDto> ordersV3() {
         List<Order> orders = orderRepository.findAllWithItems();
+        return orders.stream().map(OrderDto::new).toList();
+    }
+
+    @GetMapping("/api/v3.1/orders")
+    public List<OrderDto> ordersV3_1(
+            @RequestParam(name = "offset", defaultValue = "0") int offset,
+            @RequestParam(name = "limit", defaultValue = "100") int limit
+    ) {
+        List<Order> orders = orderRepository.findAllWithMemberDelivery(offset, limit);
         return orders.stream().map(OrderDto::new).toList();
     }
 }

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -59,6 +59,15 @@ public class OrderRepository {
                 .getResultList();
     }
 
+    public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+        return em.createQuery("select o from Order o" +
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d", Order.class)
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+
     public List<Order> findAllWithItems() {
         return em.createQuery("select distinct o from Order o" +
                 " join fetch o.member m" +

--- a/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -58,4 +58,13 @@ public class OrderRepository {
         return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
                 .getResultList();
     }
+
+    public List<Order> findAllWithItems() {
+        return em.createQuery("select distinct o from Order o" +
+                " join fetch o.member m" +
+                " join fetch o.delivery d" +
+                " join fetch o.orderItems oi" +
+                " join fetch oi.item i",
+                Order.class).getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderFlatDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderFlatDto.java
@@ -1,0 +1,36 @@
+package jpabook.jpashop.repository.order.query;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderFlatDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate; //주문시간
+    private Address address;
+    private OrderStatus orderStatus;
+
+    // OrderItem 에서 불러오는 값들
+    private String itemName;//상품 명
+    private int orderPrice; //주문 가격
+    private int count; //주문 수량
+
+    public OrderFlatDto(
+            Long orderId, String name, LocalDateTime orderDate,
+            OrderStatus orderStatus, Address address,
+            String itemName, int orderPrice, int count) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderItemQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderItemQueryDto.java
@@ -1,0 +1,21 @@
+package jpabook.jpashop.repository.order.query;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+@Data
+public class OrderItemQueryDto {
+    @JsonIgnore
+    private Long orderId; //주문번호
+    private String itemName;//상품 명
+    private int orderPrice; //주문 가격
+    private int count; //주문 수량
+
+    public OrderItemQueryDto(Long orderId, String itemName, int orderPrice, int
+            count) {
+        this.orderId = orderId;
+        this.itemName = itemName;
+        this.orderPrice = orderPrice;
+        this.count = count;
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
@@ -26,4 +26,14 @@ public class OrderQueryDto {
         this.orderStatus = orderStatus;
         this.address = address;
     }
+
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate,
+                         OrderStatus orderStatus, Address address, List<OrderItemQueryDto> orderItems) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.orderItems = orderItems;
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryDto.java
@@ -1,0 +1,29 @@
+package jpabook.jpashop.repository.order.query;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(of = "orderId")
+public class OrderQueryDto {
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate; //주문시간
+    private OrderStatus orderStatus;
+    private Address address;
+    private List<OrderItemQueryDto> orderItems;
+
+    public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate,
+                         OrderStatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
@@ -1,0 +1,52 @@
+package jpabook.jpashop.repository.order.query;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+
+    private final EntityManager em;
+
+    /**
+     * 컬렉션은 별도로 조회
+     * Query: 루트 1번, 컬렉션 N 번
+     * 단건 조회에서 많이 사용하는 방식
+     */
+    public List<OrderQueryDto> findOrderQueryDtos() {
+        //루트 조회(toOne 코드를 모두 한번에 조회)
+        List<OrderQueryDto> result = findOrders();
+
+        //루프를 돌면서 컬렉션 추가(추가 쿼리 실행)
+        result.forEach(o -> {
+            List<OrderItemQueryDto> orderItems = findOrderItems(o.getOrderId());
+            o.setOrderItems(orderItems);
+        });
+        return result;
+    }
+
+    private List<OrderQueryDto> findOrders() {
+        return em.createQuery(
+                "select new" +
+                        " jpabook.jpashop.repository.order.query.OrderQueryDto(o.id, m.username, o.orderDate, o.status, d.address)" +
+                        " from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d", OrderQueryDto.class)
+                .getResultList();
+    }
+
+    private List<OrderItemQueryDto> findOrderItems(Long orderId) {
+        return em.createQuery(
+                "select new" +
+                        " jpabook.jpashop.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" +
+                        " where oi.order.id = :orderId", OrderItemQueryDto.class)
+                .setParameter("orderId", orderId)
+                .getResultList();
+    }
+}

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
@@ -75,4 +75,16 @@ public class OrderQueryRepository {
 
         return orderItems.stream().collect(Collectors.groupingBy(oi -> oi.getOrderId()));
     }
+
+    public List<OrderFlatDto> findAllByDto_flat() {
+        return em.createQuery("select new" +
+                " jpabook.jpashop.repository.order.query.OrderFlatDto(o.id, m.username, o.orderDate,\n" +
+                        "o.status, d.address, i.name, oi.orderPrice, oi.count)" +
+                " from Order o" +
+                " join o.member m" +
+                " join o.delivery d" +
+                " join o.orderItems oi" +
+                " join oi.item i", OrderFlatDto.class)
+                .getResultList();
+    }
 }

--- a/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
+++ b/src/main/java/jpabook/jpashop/repository/order/query/OrderQueryRepository.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -48,5 +50,29 @@ public class OrderQueryRepository {
                         " where oi.order.id = :orderId", OrderItemQueryDto.class)
                 .setParameter("orderId", orderId)
                 .getResultList();
+    }
+
+    public List<OrderQueryDto> findAllByDto_optimization() {
+        List<OrderQueryDto> result = findOrders();
+
+        Map<Long, List<OrderItemQueryDto>> orderItemMap = findOrderItemMap(toOrderIds(result));
+        result.forEach(o -> o.setOrderItems(orderItemMap.get(o.getOrderId())));
+        return result;
+    }
+
+    private List<Long> toOrderIds(List<OrderQueryDto> result) {
+        return result.stream().map(o -> o.getOrderId()).toList();
+    }
+
+    private Map<Long, List<OrderItemQueryDto>> findOrderItemMap(List<Long> orderIds) {
+        List<OrderItemQueryDto> orderItems = em.createQuery("select new" +
+                        " jpabook.jpashop.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" +
+                        " where oi.order.id in :orderIds", OrderItemQueryDto.class)
+                .setParameter("orderIds", orderIds)
+                .getResultList();
+
+        return orderItems.stream().collect(Collectors.groupingBy(oi -> oi.getOrderId()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+        default_batch_fetch_size: 1000
 
 #logging:
 #  level:


### PR DESCRIPTION
### 주문 조회 V1: 엔티티 직접 노출
* 엔티티 변경시 API 스팩 변경
* 지연로딩으로 인해 쿼리 횟수 증가
* `Hibernate5Module` 모듈 설정 및 `@JsonIgnore` 설정 필수

### 주문 조회 V2: 엔티티를 DTO로 변환
* 엔티티 직접 사용으로 오는 불편함 해소
* 지연로딩으로 인해 쿼리 횟수는 아직 많음

### 주문 조회 V3: 엔티티를 DTO로 변환 - 페치 조인 최적화
* 쿼리가 1번 만 실행됨
* 일대다 관계에서는 컬랙션에 있는 모든 데이터를 불러오기 때문에 테이블 row 수가 불어난다. `distinct` 를 JPQL 에 넣어주면 데이터 자체를 DB 에서 불러올때는 SQL distinct 처럼 동작하지만 불러오고 나서 애플리케이션 자체에서 중복을 제거해준다.
* 페이징이 불가능하다.
* 컬랙션 페치조인은 한번만 사용가능하다. 두개 이상 사용시 데이터가 부정합하게 조회될수 있다.

### 주문 조회 V3.1: 엔티티를 DTO로 변환 - 페이징과 한계 돌파
* 먼저 **ToOne**(OneToOne, ManyToOne) 관계를 모두 페치조인 한다. ToOne 관계는 row수를 증가시키지 않으므로 페이징 쿼리에 영향을 주지 않는다.
* 컬렉션은 지연 로딩으로 조회한다.
* 지연 로딩 성능 최적화를 위해 `hibernate.default_batch_fetch_size` , `@BatchSize` 를 적용한다. 이 옵션을 사용하면 컬렉션이나, 프록시 객체를 한꺼번에 설정한 size 만큼 IN 쿼리로 조회한다.

#### 장점
* 조인보다 DB 데이터 전송량이 최적화 된다. (Order와 OrderItem을 조인하면 Order가 OrderItem 만큼 중복해서 조회된다. 이 방법은 각각 조회하므로 전송해야할 중복 데이터가 없다.)
* 페치 조인 방식과 비교해서 쿼리 호출 수가 약간 증가하지만, DB 데이터 전송량이 감소한다.
* 컬렉션 페치 조인은 페이징이 불가능 하지만 이 방법은 페이징이 가능하다.

### 주문 조회 V4: JPA에서 DTO 직접 조회
* 필요한 컬럼 값만 불러와서 바로 데이터 필드에 넣는다.
* ToOne(N:1, 1:1) 관계들을 먼저 조회하고, ToMany(1:N) 관계는 각각 별도로 처리한다.

### 주문 조회 V5: JPA에서 DTO 직접 조회 - 컬렉션 조회 최적화
* ToOne 관계들을 먼저 조회하고, 여기서 얻은 식별자 orderId로 ToMany 관계인 `OrderItem` 을 한꺼번에 조회
* MAP을 사용해서 매칭 성능 향상(O(1))

### 주문 조회 V6: JPA에서 DTO로 직접 조회, 플랫 데이터 최적화
* 쿼리가 1번만 실행되서 쿼리 횟수 성능은 좋다
* 일대다 관계에 있는 다른 테이블과 조인했을때 데이터가 불어나서 가져오는 데이터 양과 데이터의 중복성이 크다. 상황에 따라 쿼리는 한번이지만 더 느릴 수 있다.
* 애플리케이션에서 추가 작업이 크다
* 페이징이 안된다.

기본적으로 엔티티를 조회하여 DTO 로 변환해서 응답하는 형식을 따라 보자.
엔티티 조회안에서 최적화를 시도해보고 DTO 조회 방법을 써여 할때만 사용하자.