### PR TITLE
OSIV 알아보기 및 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
         default_batch_fetch_size: 1000
+#    open-in-view: false
 
 #logging:
 #  level:


### PR DESCRIPTION
OSIV (open session in view)
OSIV 는 요청이 시작되고 끝날때까지 DB 커넥션을 점유할 수 있게 해준다. 

장점으로는 이를 통해 지연로딩을 트랜잭션 밖 (주로 컨트롤러나 뷰 층) 에서 사용할 수 있게 해준다.
반면 단점으로는 커넥션 점유를 오래동안 하게 되면 그만큼 들어오는 요청은 DB 커넥션을 할당 받기 위해 대기 할 수도 있어서 비교적 많은 양의 요청을 처리 할 수 없게 된다.  

높은 요청처리율이 필요한 애플리케이션에서는 OSIV 를 끄는 것이 권장이 된다. 그리고 트랜잭션 밖에서 지연로딩을 사용 할 수 없는 단점은 command-query separation 디자인을 통해 해결해 볼 수 있다. 

읽기전용 서비스 컴포넌트를 따로 만들어서 추가적으로 지연로딩 로직을 활용하는 로직을 만들어서 담아두고 나머지 주요 핵심 비즈니스 로직은 따로 분리하면 유지보수면에서 도움이된다.